### PR TITLE
obs-ffmpeg: Include channel_layout.h

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -29,6 +29,7 @@
 #include <util/dstr.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <libavutil/channel_layout.h>
 
 #define ANSI_COLOR_RED "\x1b[0;91m"
 #define ANSI_COLOR_MAGENTA "\x1b[0;95m"

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -25,6 +25,7 @@
 #include "obs-ffmpeg-output.h"
 #include "obs-ffmpeg-formats.h"
 #include "obs-ffmpeg-compat.h"
+#include <libavutil/channel_layout.h>
 
 struct ffmpeg_output {
 	obs_output_t *output;


### PR DESCRIPTION
channel_layout.h needs to be included explicitly since it was removed from avcodec.h
per commit 1be3d8a0cb77 of FFmpeg.

To add as a fixup to the previous channel layout commit.
For some reason I don't get, obs wouldn't compile on macOS without these includes ...
(macOS w/ ffmpeg master)
