### PR TITLE
Resolve deprecation warnings to reflect macOS 12.0 deployment target

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -24,7 +24,7 @@ static const UInt32 kMaxFrameRateRangesInDescription = 10;
 
     if (self) {
         CMIOObjectPropertyAddress propertyAddress = {kCMIOHardwarePropertyAllowScreenCaptureDevices,
-                                                     kCMIOObjectPropertyScopeGlobal, kCMIOObjectPropertyElementMaster};
+                                                     kCMIOObjectPropertyScopeGlobal, kCMIOObjectPropertyElementMain};
 
         UInt32 allow = 1;
         CMIOObjectSetPropertyData(kCMIOObjectSystemObject, &propertyAddress, 0, NULL, sizeof(allow), &allow);

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALDevice.mm
@@ -81,7 +81,7 @@
             return sizeof(Boolean);
         case kCMIODevicePropertyLinkedCoreAudioDeviceUID:
             return sizeof(CFStringRef);
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             return sizeof(pid_t);
         default:
             break;
@@ -178,7 +178,7 @@
             *static_cast<Boolean *>(data) = false;
             *dataUsed = sizeof(Boolean);
             break;
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             *static_cast<pid_t *>(data) = self.masterPid;
             *dataUsed = sizeof(pid_t);
             break;
@@ -209,7 +209,7 @@
         case kCMIODevicePropertyExcludeNonDALAccess:
         case kCMIODevicePropertyCanProcessAVCCommand:
         case kCMIODevicePropertyCanProcessRS422Command:
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             return true;
         case kCMIODevicePropertyStreamConfiguration:
         case kCMIODevicePropertyLinkedCoreAudioDeviceUID:
@@ -244,7 +244,7 @@
         case kCMIODevicePropertyLinkedCoreAudioDeviceUID:
             return false;
         case kCMIODevicePropertyExcludeNonDALAccess:
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             return true;
         default:
             return false;
@@ -261,7 +261,7 @@
         case kCMIODevicePropertyExcludeNonDALAccess:
             self.excludeNonDALAccess = (*static_cast<const UInt32 *>(data) != 0);
             break;
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             self.masterPid = *static_cast<const pid_t *>(data);
             break;
         default:

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALObjectStore.mm
@@ -55,7 +55,7 @@
             return @"kCMIODevicePropertyStreams";
         case kCMIODevicePropertyStreamConfiguration:
             return @"kCMIODevicePropertyStreamConfiguration";
-        case kCMIODevicePropertyDeviceMaster:
+        case kCMIODevicePropertyDeviceControl:
             return @"kCMIODevicePropertyDeviceMaster";
         case kCMIODevicePropertyExcludeNonDALAccess:
             return @"kCMIODevicePropertyExcludeNonDALAccess";
@@ -192,7 +192,7 @@
             return @"kCMIOControlPropertyElement";
         case kCMIOControlPropertyVariant:
             return @"kCMIOControlPropertyVariant";
-        case kCMIOHardwarePropertyProcessIsMaster:
+        case kCMIOHardwarePropertyProcessIsMain:
             return @"kCMIOHardwarePropertyProcessIsMaster";
         case kCMIOHardwarePropertyIsInitingOrExiting:
             return @"kCMIOHardwarePropertyIsInitingOrExiting";


### PR DESCRIPTION
RE: https://github.com/obsproject/obs-studio/pull/12317, fixes master->main deprecation warnings now associated with the 12.0 deployment target.